### PR TITLE
chore: exclude dev-notes directory from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .claude/
 .playwright/
 .playwright-cli/
+dev-notes/
 
 # Screenshots and documentation files that should not be tracked
 errorscreenshorts/


### PR DESCRIPTION
## What changed
Added `dev-notes/` to `.gitignore`.

## Why
`dev-notes/` is a local-only folder for personal development notes and retrospectives. It should never be committed to the repository.