### PR TITLE
fix(frontend): remove debug log with undefined url variable

### DIFF
--- a/frontend/src/context/StoreContext.jsx
+++ b/frontend/src/context/StoreContext.jsx
@@ -145,16 +145,6 @@ function StoreContextProvider(props) {
 
   const fetchFoodList = useCallback(async () => {
     try {
-      console.log('🔍 Environment check v2:', {
-        VITE_API_URL: import.meta.env.VITE_API_URL,
-        url: url,
-        apiUrl: apiUrl,
-        mode: import.meta.env.MODE,
-        dev: import.meta.env.DEV,
-        hostname: window.location.hostname,
-        timestamp: new Date().toISOString()
-      });
-      console.log('Fetching food list from:', `${apiUrl}/api/food/list`);
       const response = await axios.get(`${apiUrl}/api/food/list`);
       
       if (!response.data || !response.data.data) {


### PR DESCRIPTION
## What
- Remove leftover debug `console.log` block (10 lines) from `fetchFoodList` in `frontend/src/context/StoreContext.jsx`

## Why
The debug log referenced an undeclared variable `url`, causing `ReferenceError: url is not defined` on every page load. This crashed `fetchFoodList` before the axios request could execute, leaving the homepage food menu completely empty.

## Test checklist
- [x] Local dev server verified: 32 food items render correctly
- [x] No ReferenceError in console

## Notes
Standalone bug fix, independent of Phase 1 Step 2.