### PR TITLE
fix: add postinstall build and remove debug console.log

### DIFF
--- a/frontend/src/components/FoodDisplay/FoodDisplay.jsx
+++ b/frontend/src/components/FoodDisplay/FoodDisplay.jsx
@@ -8,14 +8,6 @@ import PropTypes from 'prop-types';
 const FoodDisplay = ({category, searchQuery, setSearchQuery}) => {
 	const {food_list} = useContext(StoreContext);
 	
-	// Debug logging
-	console.log('🍽️ FoodDisplay rendered with:', {
-		food_list_length: food_list.length,
-		category,
-		searchQuery,
-		food_list_sample: food_list.slice(0, 2)
-	});
-
 	// Filter food items based on category and search query
 	const filteredFoodList = food_list.filter(item => {
 		const matchesCategory = category === 'All' || category === item.category;

--- a/frontend/src/context/StoreContext.jsx
+++ b/frontend/src/context/StoreContext.jsx
@@ -162,16 +162,7 @@ function StoreContextProvider(props) {
           : `${s3BaseUrl}/${item.image.startsWith('uploads/') ? item.image : 'uploads/' + item.image}`
       }));
       
-      console.log('✅ Successfully loaded', foodItems.length, 'food items');
-      console.log('🔄 Setting food list state...');
-      
-      // Only log sample URLs in development
-      if (import.meta.env.DEV) {
-        console.log('Sample image URLs:', foodItems.slice(0, 2).map(item => ({ name: item.name, image: item.image })));
-      }
-      
       setFoodList(foodItems);
-      console.log('✅ Food list state updated');
     } catch (error) {
       console.error('Error fetching food list:', error);
       console.error('Error details:', {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "pnpm --filter @food-delivery/frontend build && pnpm --filter @food-delivery/admin build",
     "build:shared": "pnpm --filter @food-delivery/shared build",
     "install:all": "pnpm install",
-    "typecheck": "pnpm --filter @food-delivery/shared typecheck && pnpm --filter @food-delivery/backend exec tsc --noEmit"
+    "typecheck": "pnpm --filter @food-delivery/shared typecheck && pnpm --filter @food-delivery/backend exec tsc --noEmit",
+    "postinstall": "pnpm --filter @food-delivery/shared build"
   },
   "engines": {
     "node": ">=18.0.0",


### PR DESCRIPTION
## What

- Add `postinstall` script to root `package.json`: automatically builds `@food-delivery/shared` after every `pnpm install`
- Remove leftover debug `console.log` from `StoreContext.jsx` (fetchFoodList function)
- Remove leftover debug `console.log` from `FoodDisplay.jsx` (component render)

## Why

After Phase 1 Step 2 merged, `packages/shared/dist/` is gitignored and not generated automatically on a fresh `git pull + pnpm install`. This caused `API_BASE_URL` and `S3_BASE_URL` to be `undefined` locally, making the food list fail to load.

The `postinstall` hook ensures `dist/` is always built after install — matching the Vercel `installCommand` behavior in production.

## Test checklist

- [ ] `pnpm install` from root now auto-builds shared without manual step
- [ ] Food list loads correctly on local dev after clean install
- [ ] No debug console.log noise in browser console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary logging statements from the application codebase.
  * Optimized build configuration for dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->