### PR TITLE
security(payment): Stripe webhook replaces URL param verification

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -137,8 +137,9 @@ const placeOrder = async (req, res) => {
 			line_items: line_items,
 			mode: 'payment',
 			payment_method_types: ['card'], // Remove au_becs_debit to support higher amounts
-			success_url: `${frontend_url}/verify?success=true&orderId=${newOrder._id}&source=new`,
+			success_url: `${frontend_url}/verify?orderId=${newOrder._id}&source=new`,
 			cancel_url: `${frontend_url}/verify?success=false&orderId=${newOrder._id}&source=new`,
+			metadata: { orderId: newOrder._id.toString() },
 			locale: 'en', // Explicitly set locale to avoid module loading issues
 			billing_address_collection: 'required',
 			shipping_address_collection: {
@@ -175,25 +176,75 @@ const userOrders = async (req, res) => {
 	}
 };
 
-//6- create one temporary payment verification system to verify the order(this is not the perfect way, the perfect way is to use B hooks)
+// Handle payment cancellation only - payment confirmation is done via webhook
 const verifyOrder = async (req, res) => {
-	const { orderId, success } = req.query;  // ✅ 改成 req.query，适配 GET 请求
+	const { orderId, success } = req.query;
 
     try {
-        if (success === 'true') {
-            await orderModel.findByIdAndUpdate(orderId, { 
-                payment: true,
-                status: "Food Processing"
-            });
-            return res.json({ success: true, message: 'Paid' });
-        } else {
+        if (success === 'false') {
+            // User cancelled payment - delete the unpaid order
             await orderModel.findByIdAndDelete(orderId);
-            return res.json({ success: false, message: 'Not Paid' });
+            return res.json({ success: false, message: 'Order cancelled' });
         }
+        // For any other case, return current payment status from DB (read-only)
+        const order = await orderModel.findById(orderId);
+        if (!order) return res.status(404).json({ success: false, message: 'Order not found' });
+        return res.json({ success: order.payment, message: order.payment ? 'Paid' : 'Pending' });
     } catch (error) {
         console.error("Order verification error:", error);
         return res.status(500).json({ success: false, message: error.message || 'Error' });
     }
+};
+
+// Poll order payment status - called by frontend while waiting for webhook
+const getOrderStatus = async (req, res) => {
+	const { orderId } = req.params;
+	try {
+		const order = await orderModel.findById(orderId);
+		if (!order) return res.status(404).json({ success: false, message: 'Order not found' });
+		return res.json({ success: true, payment: order.payment, status: order.status });
+	} catch (error) {
+		console.error('Error fetching order status:', error);
+		return res.status(500).json({ success: false, message: error.message || 'Error' });
+	}
+};
+
+// Handle Stripe webhook - the only place that sets payment: true
+const handleWebhook = async (req, res) => {
+	const sig = req.headers['stripe-signature'];
+	if (!process.env.STRIPE_WEBHOOK_SECRET) {
+		console.error('STRIPE_WEBHOOK_SECRET is not set');
+		return res.status(500).json({ success: false, message: 'Webhook secret not configured' });
+	}
+
+	let event;
+	try {
+		event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET);
+	} catch (err) {
+		console.error('Webhook signature verification failed:', err.message);
+		return res.status(400).send(`Webhook Error: ${err.message}`);
+	}
+
+	if (event.type === 'checkout.session.completed') {
+		const session = event.data.object;
+		const orderId = session.metadata?.orderId;
+		if (!orderId) {
+			console.error('Webhook: missing orderId in session metadata');
+			return res.json({ received: true });
+		}
+		try {
+			await orderModel.findByIdAndUpdate(orderId, {
+				payment: true,
+				status: 'Food Processing'
+			});
+			console.log(`Webhook: order ${orderId} marked as paid`);
+		} catch (error) {
+			console.error('Webhook: error updating order:', error);
+			return res.status(500).json({ success: false, message: 'Error updating order' });
+		}
+	}
+
+	res.json({ received: true });
 };
 
 //2- API: Listing orders for admin panel - fetch all the orders of all the users
@@ -305,8 +356,9 @@ const retryPayment = async (req, res) => {
 			line_items: line_items,
 			mode: 'payment',
 			payment_method_types: ['card'],
-			success_url: `${frontend_url}/verify?success=true&orderId=${existingOrder._id}&source=retry`,
+			success_url: `${frontend_url}/verify?orderId=${existingOrder._id}&source=retry`,
 			cancel_url: `${frontend_url}/verify?success=false&orderId=${existingOrder._id}&source=retry`,
+			metadata: { orderId: existingOrder._id.toString() },
 			locale: 'en', // Explicitly set locale to avoid module loading issues
 			billing_address_collection: 'required',
 			shipping_address_collection: {
@@ -401,4 +453,4 @@ const deleteOrder = async (req, res) => {
 };
 
 // export placeOrder function and it will be imported in orderRoute.js
-export {placeOrder, userOrders, verifyOrder, listOrders, updateStatus, retryPayment, editOrder, deleteOrder};
+export {placeOrder, userOrders, verifyOrder, getOrderStatus, handleWebhook, listOrders, updateStatus, retryPayment, editOrder, deleteOrder};

--- a/backend/routes/orderRoute.js
+++ b/backend/routes/orderRoute.js
@@ -6,6 +6,8 @@ import {
 	placeOrder,
 	userOrders,
 	verifyOrder,
+	getOrderStatus,
+	handleWebhook,
 	listOrders,
   updateStatus,
   retryPayment,
@@ -23,9 +25,12 @@ const orderRouter = express.Router();
 
 // 1- place order end point
 orderRouter.post('/place', authMiddleware, placeOrder);
-// 2- place order verification end point
-orderRouter.post('/verify', verifyOrder);
+// 2- Stripe webhook - no auth, raw body already handled in server.js
+orderRouter.post('/webhook', handleWebhook);
+// 3- cancellation check only - no longer sets payment:true
 orderRouter.get('/verify', verifyOrder);
+// 4- poll order payment status (frontend polls after redirect from Stripe)
+orderRouter.get('/status/:orderId', authMiddleware, getOrderStatus);
 
 // 3- create end point for userOrders
 orderRouter.post('/userorders', authMiddleware, userOrders);

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,6 +12,10 @@ import orderRouter from './routes/orderRoute.js';
 // app config
 const app = express();
 
+// Webhook route must receive raw body for Stripe signature verification
+// Must be registered BEFORE express.json() parses the body
+app.use('/api/order/webhook', express.raw({ type: 'application/json' }));
+
 // initialize the middleware
 app.use(express.json());
 

--- a/frontend/src/pages/Verify/Verify.jsx
+++ b/frontend/src/pages/Verify/Verify.jsx
@@ -50,85 +50,66 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { StoreContext } from '../../context/StoreContext';
 import axios from 'axios';
 
+const POLL_INTERVAL_MS = 2000;
+const POLL_MAX_ATTEMPTS = 30; // 60 seconds total
+
 const Verify = () => {
-  const [searchParams] = useSearchParams(); // ✅ 确保 searchParams 只读
-  const success = searchParams.get("success");
+  const [searchParams] = useSearchParams();
+  const success = searchParams.get("success"); // only present on cancellation
   const orderId = searchParams.get("orderId");
-  const source = searchParams.get("source"); // Get payment source from URL
+  const source = searchParams.get("source");
   const { url } = useContext(StoreContext);
   const navigate = useNavigate();
 
   useEffect(() => {
-    console.log('🔵 Verify component mounted');
-    console.log('🔵 URL params - success:', success, 'orderId:', orderId, 'source:', source);
-    console.log('🔵 Current sessionStorage fromPayment:', sessionStorage.getItem('fromPayment'));
-    
-    const verifyPayment = async () => {
-      try {
-        console.log("🔄 发送 `GET` 请求到:", `${url}/api/order/verify?success=${success}&orderId=${orderId}`);
-
-        const response = await axios.get(`${url}/api/order/verify?success=${success}&orderId=${orderId}`);
-
-        console.log("✅ 响应数据:", response.data);
-
-        if (response.data.success) {
-          // Payment successful, always go to orders page to see the updated status
-          sessionStorage.removeItem('fromPayment');
-          navigate("/myorders");
-        } else {
-          // Payment failed, determine where to return based on payment source
-          const paymentSource = source || sessionStorage.getItem('fromPayment');
-          console.log('🔴 Payment failed!');
-          console.log('📍 Payment source from URL:', source);
-          console.log('📍 Payment source from sessionStorage:', sessionStorage.getItem('fromPayment'));
-          console.log('📍 Final payment source used:', paymentSource);
-          
-          if (paymentSource === 'retry') {
-            // This was a retry payment from MyOrders, return to MyOrders
-            console.log('✅ Returning to MyOrders (retry payment)');
-            sessionStorage.removeItem('fromPayment');
-            navigate("/myorders");
-          } else {
-            // This was a new order from Cart, return to Cart
-            console.log('✅ Returning to Cart (new order)');
-            sessionStorage.removeItem('fromPayment');
-            navigate("/cart");
-          }
-        }
-      } catch (error) {
-        console.error("❌ 验证请求失败:", error);
-        // On error, determine where to return based on payment source
-        const paymentSource = source || sessionStorage.getItem('fromPayment');
-        console.log('❌ Error occurred, payment source:', paymentSource);
-        
-        if (paymentSource === 'retry') {
-          sessionStorage.removeItem('fromPayment');
-          navigate("/myorders");
-        } else {
-          sessionStorage.removeItem('fromPayment');
-          navigate("/cart");
-        }
-      }
+    const paymentSource = source || sessionStorage.getItem('fromPayment');
+    const returnOnFailure = () => {
+      sessionStorage.removeItem('fromPayment');
+      navigate(paymentSource === 'retry' ? '/myorders' : '/cart');
     };
 
-    // ✅ 只有当 success 和 orderId 存在时才执行请求
-    if (success && orderId) {
-      verifyPayment();
-    } else {
-      console.error("⚠️ 缺少 `success` 或 `orderId`，无法发送验证请求");
-      // Determine where to return based on payment source
-      const paymentSource = source || sessionStorage.getItem('fromPayment');
-      console.log('⚠️ Missing success/orderId, payment source:', paymentSource);
-      
-      if (paymentSource === 'retry') {
-        sessionStorage.removeItem('fromPayment');
-        navigate("/myorders");
-      } else {
-        sessionStorage.removeItem('fromPayment');
-        navigate("/cart");
-      }
+    // User cancelled payment on Stripe page
+    if (success === 'false') {
+      axios.get(`${url}/api/order/verify?success=false&orderId=${orderId}`)
+        .catch(err => console.error('Cancel order error:', err))
+        .finally(returnOnFailure);
+      return;
     }
-  }, [success, orderId, source, url, navigate]); // ✅ 确保 useEffect 只在相关参数变化时触发
+
+    if (!orderId) {
+      returnOnFailure();
+      return;
+    }
+
+    // Poll for webhook confirmation (Stripe → backend → DB)
+    let attempts = 0;
+    const poll = setInterval(async () => {
+      attempts++;
+      try {
+        const response = await axios.get(
+          `${url}/api/order/status/${orderId}`,
+          { withCredentials: true }
+        );
+        if (response.data.payment === true) {
+          clearInterval(poll);
+          sessionStorage.removeItem('fromPayment');
+          navigate('/myorders');
+        } else if (attempts >= POLL_MAX_ATTEMPTS) {
+          clearInterval(poll);
+          sessionStorage.removeItem('fromPayment');
+          navigate('/myorders');
+        }
+      } catch (error) {
+        console.error('Error polling order status:', error);
+        if (attempts >= POLL_MAX_ATTEMPTS) {
+          clearInterval(poll);
+          returnOnFailure();
+        }
+      }
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(poll);
+  }, [orderId, success, source, url, navigate]);
 
   return (
     <div className='verify'>


### PR DESCRIPTION
## What

Replace the insecure URL-parameter payment verification with a proper Stripe webhook flow.

## Why

The old `verifyOrder` read `?success=true` from the URL and immediately set `payment: true` in the database. Anyone who knew an `orderId` could forge this GET request and mark an order as paid without spending a cent.

## Changes

**`backend/server.js`**
- Register `express.raw()` for `/api/order/webhook` before `express.json()` — required to preserve raw bytes for HMAC signature verification

**`backend/controllers/orderController.js`**
- `handleWebhook`: verifies `stripe-signature` header via `stripe.webhooks.constructEvent()`, then sets `payment: true` only on confirmed `checkout.session.completed` events
- `getOrderStatus`: read-only poll endpoint, returns current `payment` + `status` fields
- `verifyOrder`: now handles cancellation only (deletes unpaid order when `success=false`)
- Added `metadata: { orderId }` to Stripe session creation in `placeOrder` and `retryPayment`

**`backend/routes/orderRoute.js`**
- `POST /webhook` — no auth middleware (Stripe calls this directly)
- `GET /status/:orderId` — auth-protected polling endpoint

**`frontend/src/pages/Verify/Verify.jsx`**
- Replaces single GET to `/api/order/verify?success=true` with polling `/api/order/status/:orderId` every 2s
- Polls up to 30 times (60s) waiting for webhook to confirm payment
- Cancellation (`success=false`) still calls verify endpoint to clean up the DB

## Before vs After

| | Before | After |
|---|---|---|
| Payment confirmed by | URL `?success=true` (client-controlled) | Stripe webhook POST (server-to-server, HMAC signed) |
| Forgeable? | Yes — anyone with orderId | No — signature verified against `STRIPE_WEBHOOK_SECRET` |
| DB write | `verifyOrder` on GET request | `handleWebhook` only |
| Frontend wait | Immediate redirect | Polls every 2s until `payment: true` |

## Manual setup required after merge

1. In Stripe Dashboard → Webhooks → Add endpoint: `https://backend-ten-azure-58.vercel.app/api/order/webhook`
2. Select event: `checkout.session.completed`
3. Copy the signing secret → add as `STRIPE_WEBHOOK_SECRET` in Vercel backend environment variables
4. Redeploy backend on Vercel

## Test plan
- [ ] Cancelling payment deletes the order and returns to cart
- [ ] Completing payment → Stripe sends webhook → DB updates → frontend polls and redirects to /myorders
- [ ] Forging `GET /api/order/verify?success=true&orderId=xxx` no longer sets payment:true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order status verification enhanced with continuous tracking
  * Real-time payment status updates now available

* **Improvements**
  * Better error handling and recovery for failed payments and order cancellations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->